### PR TITLE
Change email to identity

### DIFF
--- a/model_signing/README.md
+++ b/model_signing/README.md
@@ -35,14 +35,14 @@ python3 main.py sign --path "${path}"
 # Verification.
 python3 main.py verify -h
 python3 main.py verify --path "${path}" \
-    --email-provider https://accounts.google.com \
-    --email myemail@gmail.com
+    --identity-provider https://accounts.google.com \
+    --identity myemail@gmail.com
 
 # Leave the venv.
 deactivate
 ```
 
-### Supported Email Providers
+### Supported Identity Providers
 
 Google's provider is `https://accounts.google.com`.
 
@@ -64,8 +64,8 @@ mkdir -p "${model_path}"
 cd "${model_path}" && tar xvzf ../"${model_path}".tgz && rm ../"${model_path}".tgz && cd -
 python3 main.py sign --path "${model_path}"
 python3 main.py verify --path "${model_path}" \
-    --email-provider https://accounts.google.com \
-    --email myemail@gmail.com
+    --identity-provider https://accounts.google.com \
+    --identity myemail@gmail.com
 ```
 
 #### Hugging face
@@ -86,8 +86,8 @@ model_path="${model_name}"
 git clone "https://huggingface.co/${model_name}"
 python3 main.py sign --path "${model_path}"
 python3 main.py verify --path "${model_path}" \
-    --email-provider https://accounts.google.com \
-    --email myemail@gmail.com
+    --identity-provider https://accounts.google.com \
+    --identity myemail@gmail.com
 ```
 
 Example for Falcon model:
@@ -99,8 +99,8 @@ model_path=$(echo "${model_name}" | cut -d/ -f2)
 git clone "https://huggingface.co/${model_name}"
 python3 main.py sign --path "${model_path}"
 python3 main.py verify --path "${model_path}" \
-    --email-provider https://accounts.google.com \
-    --email myemail@gmail.com
+    --identity-provider https://accounts.google.com \
+    --identity myemail@gmail.com
 ```
 
 #### PyTorch Hub
@@ -114,8 +114,8 @@ model_path=$(echo "${model_name}" | cut -d/ -f2)
 git clone "https://github.com/${model_name}.git"
 python3 main.py sign --path "${model_path}"
 python3 main.py verify --path "${model_path}" \
-    --email-provider https://accounts.google.com \
-    --email myemail@gmail.com
+    --identity-provider https://accounts.google.com \
+    --identity myemail@gmail.com
 ```
 
 #### ONNX
@@ -129,6 +129,6 @@ model_path="${model_name}.onnx"
 wget "https://github.com/onnx/models/raw/main/text/machine_comprehension/roberta/model/${model_name}.onnx"
 python3 main.py sign --path "${model_path}"
 python3 main.py verify --path "${model_path}" \
-    --email-provider https://accounts.google.com \
-    --email myemail@gmail.com
+    --identity-provider https://accounts.google.com \
+    --identity myemail@gmail.com
 ```

--- a/model_signing/main.py
+++ b/model_signing/main.py
@@ -38,8 +38,8 @@ def readOptions():
         "verify", formatter_class=argparse.ArgumentDefaultsHelpFormatter
     )
 	verify.add_argument("--path", required=True, help="The path to a file to verify")
-	verify.add_argument("--email", required=True, help="The email to verify")
-	verify.add_argument("--email-provider", required=True, help="The OIDC provider to verify")
+        verify.add_argument("--identity", required=True, help="The identity (email, workload identity) to verify")
+	verify.add_argument("--identity-provider", required=True, help="The OIDC provider to verify")
 
 	args = parser.parse_args()
 	return args
@@ -54,8 +54,8 @@ def sign(modelfn: Path, use_ambiant: bool) -> model.SignatureResult:
 	signer = model.SigstoreSigner(use_ambiant = use_ambiant)
 	return signer.sign(modelfn, signature_path(modelfn))
 
-def verify(modelfn: Path, issuer:str, email:str, offline = False)-> model.VerificationResult:
-	verifier = model.SigstoreVerifier(oidc_provider=issuer, email=email)
+def verify(modelfn: Path, issuer:str, identity:str, offline = False)-> model.VerificationResult:
+	verifier = model.SigstoreVerifier(oidc_provider=issuer, identity=identity)
 	return verifier.verify(modelfn, signature_path(modelfn), offline)
 
 def main(args) -> int:
@@ -69,8 +69,8 @@ def main(args) -> int:
 	elif args.subcommand == "verify":
 		modelfn = Path(args.path)
 		result = verify(modelfn=modelfn, 
-	 	  issuer=args.email_provider,
-	 	  email=args.email,
+	 	  issuer=args.identity_provider,
+	 	  identity=args.identity,
 	 	)
 		if result:
 			print("verification success")

--- a/model_signing/model.py
+++ b/model_signing/model.py
@@ -105,9 +105,9 @@ class VerificationResult(BaseResult):
     pass
 
 class SigstoreVerifier():
-    def __init__(self, oidc_provider: str, email: str):
+    def __init__(self, oidc_provider: str, identity: str):
         self.oidc_provider = oidc_provider
-        self.email = email
+        self.identity = identity
         self.verifier = Verifier.production()
 
     def verify(self, inputfn: Path, signaturefn: Path, offline: bool) -> VerificationResult:
@@ -119,7 +119,7 @@ class SigstoreVerifier():
             contentio = io.BytesIO(Serializer.serialize(inputfn, signaturefn))
             material = VerificationMaterials.from_bundle(input_=contentio, bundle=bundle, offline=offline)
             policy_ = policy.Identity(
-                identity=self.email,
+                identity=self.identity,
                 issuer=self.oidc_provider,
             )
             result = self.verifier.verify(materials=material, policy=policy_)


### PR DESCRIPTION
Sigstore supports more than just email, including CI workflow identity. This clarifies that we support signing on CI platforms, not just signing with an email.