### PR TITLE
Revert "build(deps): bump actions/setup-python from 4.7.0 to 4.7.1"

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4.0.0
-      - uses: actions/setup-python@65d7f2d534ac1bc67fcd62888c5f4f3d2cb2b236 # v4.7.1
+      - uses: actions/setup-python@61a6322f88396a6271a6ee3565807d608ecaddd1 # v4.7.0
       - run: |
           set -euo pipefail
           cd model_signing


### PR DESCRIPTION
Reverts google/model-transparency#30

Reverting because it breaks `pip` package resolution: [working](https://github.com/mihaimaruseac/model-transparency/actions/runs/6626589695/job/17999819797), [broken](https://github.com/mihaimaruseac/model-transparency/actions/runs/6631077841/job/18013816004#step:4:177): both have 

```
Collecting etils[array-types,enp,epath,epy,etqdm,etree]==1.5.1 (from -r slsa_for_models/install/requirements.txt (line 190))
  Using cached etils-1.5.1-py3-none-any.whl (140 kB)
```

in the log, but the one after the action bump is then trying to look for 

```
Collecting etils[epath] (from array-record==0.5.0->-r slsa_for_models/install/requirements.txt (line 18))
ERROR: In --require-hashes mode, all requirements must have their versions pinned with ==. These do not:
    etils[epath] from https://files.pythonhosted.org/packages/0f/6a/d2aaebacf73d5da7126c632ec0d9dc2df99cc4bbd259bad48904a034fc1b/etils-1.5.2-py3-none-any.whl (from array-record==0.5.0->-r slsa_for_models/install/requirements.txt (line 18))
```