### PR TITLE
Add CI to make sure dependencies are always installable

### DIFF
--- a/.github/workflows/validate_deps.yml
+++ b/.github/workflows/validate_deps.yml
@@ -1,0 +1,45 @@
+name: Validate all Python dependencies work together
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+    types: [opened, synchronize]
+
+permissions:
+  id-token: write
+
+jobs:
+  model-signing:
+    name: Test model signing dependencies
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+    - uses: actions/setup-python@65d7f2d534ac1bc67fcd62888c5f4f3d2cb2b236 # v4.7.1
+      with:
+        python-version: 3.11
+        cache: pip
+        cache-dependency-path: model_signing/install/requirements.txt
+    - name: Install dependencies
+      run: |
+        set -euo pipefail
+        python -m venv venv
+        source venv/bin/activate
+        python -m pip install --require-hashes -r model_signing/install/requirements.txt
+
+  slsa-for-m:
+    name: Test SLSA for ML demo dependencies
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+    - uses: actions/setup-python@65d7f2d534ac1bc67fcd62888c5f4f3d2cb2b236 # v4.7.1
+      with:
+        python-version: 3.11
+        cache: pip
+        cache-dependency-path: slsa_for_models/install/requirements.txt
+    - name: Install dependencies
+      run: |
+        set -euo pipefail
+        python -m venv venv
+        source venv/bin/activate
+        python -m pip install --require-hashes -r slsa_for_models/install/requirements.txt


### PR DESCRIPTION
Replaces #41 by only testing that dependencies can be installed (so we no longer have to manually detect them as in #37 or get to a revert like #42). Closes #41 as deprecated upon merging.

Bumps the checkout actions to latest version as a bonus