### PR TITLE
deps: Reduce number of PRs by grouping dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,12 +13,21 @@
 # limitations under the License.
 
 version: 2
+# See https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file.
 updates:
   - package-ecosystem: "pip"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
+    groups:
+      all:
+        patterns:
+        - "*"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
+    groups:
+      all:
+        patterns:
+        - "*"


### PR DESCRIPTION
By default Dependabot sends on PR for each version update. This PR changes this to send a single weekly PR with all updates for each ecosystem (pip and GHA). So we should receive 2 PRs / week