### PR TITLE
fix: pytest command not found

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -29,4 +29,4 @@ jobs:
     - name: Run unit tests
       run: |
         set -euo pipefail
-        pytest .
+        ./venv/bin/pytest .


### PR DESCRIPTION
Not sure why the command is not found, especially since the correct directory is listed in the PATH.