### PR TITLE
This time fix SLSA 4 ML workflow for real.

### DIFF
--- a/.github/workflows/slsa_for_ml.yml
+++ b/.github/workflows/slsa_for_ml.yml
@@ -35,8 +35,9 @@ jobs:
         cache-dependency-path: slsa_for_models/install/requirements_${{ runner.os }}.txt
     - name: Install dependencies
       run: |
-        set -euo pipefail
-        bash .github/workflows/scripts/venv_setup.sh
+        set -exuo pipefail
+        python -m venv venv
+        .github/workflows/scripts/venv_activate.sh
         python -m pip install --require-hashes -r slsa_for_models/install/requirements_${{ runner.os }}.txt
     - name: Build model
       env:


### PR DESCRIPTION
In #87, I missed one of the venv activations :( (we need one for each step of the CI because a new bash session starts for each `run` step).

Now it's fixed.