### PR TITLE
SLSA for Models on GCP

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,16 +68,12 @@ See [model_signing/README.md](model_signing/README.md) for more information.
 
 ### SLSA for ML
 
-This project shows how we can use the [SLSA L3 GitHub generator][slsa-generator]
-to generate SLSA provenance for ML models. The SLSA generator was originally
-developed for traditional software to protect against tampering with builds,
-such as in the [Solarwinds attack][solarwinds], and this project is a proof of
-concept that the same supply chain protections can be applied to ML.
+This project shows how we can generate [SLSA][slsa] provenance for ML models.
 
-While most of the ML models are currently too expensive to train using the SLSA
-generator on GitHub Actions, future work will cover the training of ML models
-that require access to accelerators (i.e., GPUs, TPUs) or that require multiple
-hours for training.
+SLSA was originally developed for traditional software to protect against
+tampering with builds, such as in the [Solarwinds attack][solarwinds], and
+this project is a proof of concept that the same supply chain protections
+can be applied to ML.
 
 See [slsa_for_models/README.md](slsa_for_models/README.md) for more information.
 
@@ -91,6 +87,7 @@ used in any production environment.
 
 Please see the [Contributor Guide](CONTRIBUTING.md) for more information.
 
+[slsa]: https://slsa.dev/
 [saif]: https://blog.google/technology/safety-security/introducing-googles-secure-ai-framework/
 [openssf]: https://openssf.org/
 [slsa-generator]: https://github.com/slsa-framework/slsa-github-generator

--- a/slsa_for_models/README.md
+++ b/slsa_for_models/README.md
@@ -1,34 +1,29 @@
 # SLSA for Models
 
-This project shows how we can use the [SLSA L3 GitHub generator][slsa-generator]
-to generate SLSA provenance for ML models. The SLSA generator was originally
-developed for traditional software to protect against tampering with builds,
-such as in the [Solarwinds attack][solarwinds], and this project is a proof of
-concept that the _same supply chain protections can be applied to ML_.
+This project shows how we can generate [SLSA][slsa] provenance for ML models
+on [GitHub Actions][gha] and [Google Cloud Platform][gcp].
 
-Future work will involve covering training ML models that require access to
-accelerators (i.e., GPUs, TPUs) or that require multiple hours for training. As
-an example, we could use [Tekton Chains][tekton-chains] to support [training ML
-models using Kubeflow][tekton-kubeflow].
+SLSA was originally developed for traditional software to protect against
+tampering with builds, such as in the [Solarwinds attack][solarwinds], and
+this project is a proof of concept that the _same supply chain protections
+can be applied to ML_.
 
-When users download a given version of a model they can also check its
-provenance by using [the SLSA verifier][slsa-verifier] repository. This can be
-integrated in the model hub and/or model serving platforms: for example the
-model serving pipeline could validate provenance for all new models before
-serving them. However, the verification can also be done manually, on demand, as
-we will do by the end of this README.
+When users download a given version of a model they can also check its provenance.
+This can be integrated in the model hub and/or model serving platforms: for example
+the model serving pipeline could validate provenance for all new models before
+serving them. However, the verification can also be done manually, on demand.
 
 As an additional benefit, having provenance for a model allows users to react
 to vulnerabilities in a training framework: they can quickly determine if a
 model needs to be retrained because it was created using a vulnerable version.
 
-## Usage
+See the guides for [GitHub Actions][gha] and [Google Cloud Platform][gcp] for details.
+
+## Models
 
 We support both TensorFlow and PyTorch models. The example repo trains a model
 on [CIFAR10][cifar10] dataset, saves it in one of the supported formats, and
-generates provenance for the output. All of this happens during a [GitHub Actions
-workflow][workflow] which takes as input the format to save the model into. The
-supported formats are:
+generates provenance for the output. The supported formats are:
 
 | Workflow Argument            | Training Framework | Model format                    |
 |------------------------------|--------------------|---------------------------------|
@@ -39,40 +34,24 @@ supported formats are:
 | `pytorch_full_model.pth`     | PyTorch            | PyTorch complete model format   |
 | `pytorch_jitted_model.pt`    | PyTorch            | PyTorch TorchScript format      |
 
-To test, fork this repository, then head over to the Actions tab and select the
-"SLSA for ML models example" workflow. Since the workflow has a
-`workflow_dispatch` trigger, it can be invoked on demand: click the `Run
-workflow` button, then select the value for the "Name of the model" argument.
+While most of the ML models are currently too expensive to train, future work will
+cover the training of ML models that require access to accelerators (i.e., GPUs, TPUs)
+or that require multiple hours for training.
 
-![Triggering a SLSA workflow](images/slsa_trigger.png)
+## Future Work
 
-After the workflow finishes execution, there will be two archives in the
-"Artifacts" section: one is the model that was trained and the other one is the
-SLSA provenance attached to the model.
+### Accelerators
+Future work will involve covering training ML models that require access to
+accelerators (i.e., GPUs, TPUs) or that require multiple hours for training. As
+an example, we could use [Tekton Chains][tekton-chains] to support [training ML
+models using Kubeflow][tekton-kubeflow].
 
-![Results of running a SLSA workflow](images/slsa_results.png)
+### Platforms
+While this example has targeted GitHub Actions and Tekton in GCP, we aim to bring
+support for other platforms (e.g., GCB and GitLab) and model training environments.
 
-To verify the provenance, download both archives, unzip each and then run
-`slsa-verifier`, making sure to replace the `--source-uri` argument with the
-_path to your fork_. For example, for a PyTorch model, which has been [built on
-this repository](https://github.com/google/model-transparency/actions/runs/6646816974):
-
-```console
-[...]$ slsa-verifier verify-artifact \
-       --provenance-path pytorch_model.pth.intoto.jsonl \
-       --source-uri github.com/google/model-transparency \
-       pytorch_model.pth
-Verified signature against tlog entry index 45419124 at URL: https://rekor.sigstore.dev/api/v1/log/entries/24296fb24b8ad77a98dd03d23a78657e7f1efd3d9bea6988abbf23a72290a4ec7dc35c9edeab7ee1
-Verified build using builder "https://github.com/slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@refs/tags/v1.9.0" at commit ac26cbf66849cfec6f29747f4525180595c7eef0
-Verifying artifact pytorch_model.pth: PASSED
-
-PASSED: Verified SLSA provenance
-```
-
-The verification of provenance can be done just before the model gets loaded in the
-serving pipeline.
-
-**Note**: TensorFlow also supports saving models in `SavedModel` format. This is
+### Directory Format
+TensorFlow also supports saving models in `SavedModel` format. This is
 a directory-based serialization format and currently we don't fully support
 this. We can generate SLSA provenance for all the files in the directory but
 there are caveats regarding verification. Furthermore, because there is a
@@ -80,9 +59,6 @@ difference between the hashes generated by provenance and the hash generated
 during model signing, we have decided to add support for these model formats at
 a future time, after standardizing a way to generate and verify provenance in
 SLSA (in general, not just for ML).
-
-While this example has targeted GitHub Actions, we aim to bring support
-for other platforms (e.g., GCB and GitLab) and model training environments.
 
 [cifar10]: https://www.cs.toronto.edu/~kriz/cifar.html
 [slsa-generator]: https://github.com/slsa-framework/slsa-github-generator
@@ -92,3 +68,5 @@ for other platforms (e.g., GCB and GitLab) and model training environments.
 [tekton-chains]: https://github.com/tektoncd/chains
 [tekton-kubeflow]: https://www.kubeflow.org/docs/components/pipelines/v1/sdk/pipelines-with-tekton/
 [workflow]: https://github.com/google/model-transparency/blob/main/.github/workflows/slsa_for_ml.yml
+[gha]: github_actions
+[gcp]: gcp

--- a/slsa_for_models/gcp/README.md
+++ b/slsa_for_models/gcp/README.md
@@ -1,0 +1,247 @@
+# SLSA for Models on Google Cloud Platform
+
+This project uses [Tekton][tekton] to generate SLSA provenance for ML models on Google Cloud Platform (GCP). It uses 
+[Google Kubernetes Engine][gke] (GKE), [Artifact Registry][ar], [Tekton] and [Sigstore].
+
+## Guide
+
+1. To get started, you'll need to have a [GCP Project][gcp]. You will also need to have these CLI tools installed:
+   - [`gcloud`][gcloud]
+   - [`kubectl`][kubectl]
+   - [`tkn`][tkn]
+   - [`cosign`][cosign]
+
+2. Enable the needed services:
+
+   ```shell
+   gcloud services enable \
+     container.googleapis.com \
+     artifactregistry.googleapis.com
+   ```
+
+3. Create a GKE cluster:
+
+    1. Set the `PROJECT_ID` environment variable from your GCP project:
+   
+       ```shell
+       export PROJECT_ID=<PROJECT_ID>
+       ```
+   
+   2. Set the `CLUSTER_NAME` environment variable to a cluster name of your choice:
+   
+      ```shell
+      export CLUSTER_NAME=<CLUSTER_NAME>
+      ```
+   
+   3. Create a cluster:
+   
+       ```shell
+       gcloud container clusters create $CLUSTER_NAME \
+       --enable-autoscaling \
+       --min-nodes=1 \
+       --max-nodes=3 \
+       --scopes=cloud-platform \
+       --no-issue-client-certificate \
+       --project=$PROJECT_ID \
+       --region=us-central1 \
+       --machine-type=e2-standard-4 \
+       --num-nodes=1 \
+       --cluster-version=latest
+       ```
+
+4. Install Tekton:
+
+   1. Install Tekton Pipelines:
+   
+       ```shell
+       kubectl apply --filename https://storage.googleapis.com/tekton-releases/pipeline/latest/release.yaml
+       ``` 
+   
+   2. Install Tekton Chains:
+   
+       ```shell
+       kubectl apply --filename https://storage.googleapis.com/tekton-releases/chains/latest/release.yaml
+       ```
+
+5. Verify your Tekton installation was successful:
+
+   1. Check that Tekton Pipelines Pods are running in Kubernetes:
+
+       ```shell
+       kubectl get pods -n tekton-pipelines
+       ```
+
+   2. Check that Tekton Chains Pods are running in Kubernetes:
+
+      ```shell
+      kubectl get pods -n tekton-chains 
+      ``` 
+
+6. Configure Tekton:
+
+   1. Configure Tekton Pipelines to enable enumerations and alpha features:
+   
+       ```shell
+       kubectl patch cm feature-flags -n tekton-pipelines -p '{"data":{
+       "enable-param-enum":"true",
+       "enable-api-fields":"alpha" 
+       }}'  
+       ```
+
+   2. Then restart the Tekton Pipelines controller to ensure it picks up the changes:
+      
+      ```shell
+      kubectl delete pods -n tekton-pipelines -l app=tekton-pipelines-controller
+      ``` 
+   
+   3. Configure Tekton Chains to enable transparency log, set SLSA format and configure storage:
+ 
+      ```shell
+      kubectl patch configmap chains-config -n tekton-chains -p='{"data":{
+      "transparency.enabled": "true",
+      "artifacts.taskrun.format":"slsa/v2alpha2", 
+      "artifacts.taskrun.storage": "tekton",
+      "artifacts.pipelinerun.format":"slsa/v2alpha2", 
+      "artifacts.pipelinerun.storage": "tekton"
+      }}'
+      ```
+   4. Then restart the Tekton Chains controller to ensure it picks up the changes:
+
+      ```shell
+      kubectl delete pods -n tekton-chains -l app=tekton-chains-controller 
+      ```    
+
+7. Generate an encrypted x509 keypair and save it as a Kubernetes secret:
+   
+   ```shell
+   cosign generate-key-pair k8s://tekton-chains/signing-secrets
+   ```
+ 
+8. Apply the `Tasks`:
+
+   ```shell
+   kubectl apply -f slsa_for_models/gcp/tasks
+   ```
+
+9. Apply the `Pipeline`:
+
+   ```shell
+   kubectl apply -f slsa_for_models/gcp/pipeline.yml
+   ```
+ 
+10. Create a generic repository in Artifact Registry:
+
+    1. Set the `REPOSITORY_NAME` environment variable to a name of your choice:
+
+       ```shell
+       export REPOSITORY_NAME=ml-artifacts
+       ```
+
+    2. Set the `LOCATION` environment variable to a [location] of your choice:
+
+       ```shell
+       export LOCATION=us
+       ```
+       
+    3. Create a generic repository:
+        ```shell
+        gcloud artifacts repositories create $REPOSITORY_NAME \
+         --location=$LOCATION \
+         --repository-format=generic
+        ```   
+   
+    4. If you set a different repository name and location from the example above, make sure to modify the `Parameter`
+    named 'model-storage' in the `PipelineRun` with your own values. 
+
+11. Execute the `PipelineRun`:
+
+    ```shell
+    kubectl create -f slsa_for_models/gcp/pipelinerun.yml
+    ```
+
+12. Observe the `PipelineRun` execution:
+
+    ```shell
+    export PIPELINERUN_NAME=$(tkn pr describe --last --output jsonpath='{.metadata.name}')
+    tkn pipelinerun logs $PIPELINERUN_NAME --follow
+    ``` 
+
+13. When the `PipelineRun` succeeds, view its status:
+
+    ```shell
+    kubectl get pipelinerun $PIPELINERUN_NAME --output yaml
+    ```
+
+14. View the transparency log entry in the public [Rekor][rekor] instance:
+
+   ```shell
+   export TLOG_ENTRY=$(tkn pr describe $PIPELINERUN_NAME --output jsonpath="{.metadata.annotations.chains\.tekton\.dev/transparency}")
+   open $TLOG_ENTRY
+   ```
+   
+15. Retrieve the attestation from the `PipelineRun` which is stored as a base64-encoded annotation:
+
+   ```shell
+   export PIPELINERUN_UID=$(tkn pr describe $PIPELINERUN_NAME --output  jsonpath='{.metadata.uid}')
+   tkn pr describe $PIPELINERUN_NAME --output jsonpath="{.metadata.annotations.chains\.tekton\.dev/signature-pipelinerun-$PIPELINERUN_UID}" | base64 -d > pytorch_model.pth.build-slsa 
+   ```
+
+16. View the attestation:
+
+   ```shell
+   cat pytorch_model.pth.build-slsa | tr -d '\n' | pbcopy
+   pbpaste | jq '.payload | @base64d | fromjson'
+   ```
+17. Download the model:
+
+   ```shell
+   export MODEL_VERSION=$(tkn pr describe slsa-for-models-pr --output jsonpath='{.status.results[1].value.digest}' | cut -d ':' -f 2)
+   gcloud artifacts generic download \
+   --package=pytorch-model \
+   --repository=$REPOSITORY_NAME \
+   --destination=. \
+   --version="${MODEL_VERSION:7}"
+   ```
+
+18. Verify the attestation:
+
+   ```shell
+   cosign verify-blob-attestation \
+    --key k8s://tekton-chains/signing-secrets \
+    --signature pytorch_model.pth.build-slsa \
+    --type slsaprovenance1 \
+    pytorch_model.pth
+   ```
+
+## Future Work
+
+### Automate Provenance Verification
+
+Demonstrate how to verify the provenance of the model before deploying and serving the model.
+
+### Automated Testing
+
+Trigger execution of the `PipelineRun` whenever changes are made in the codebase.
+
+### Kubeflow on Tekton
+
+Provide a Kubeflow Pipeline that can be compiled into the above Tekton Pipeline using [Kubeflow on Tekton][tekton-kubeflow].
+
+### Accelerators
+
+Demonstrate training ML models that require multiple hours for training and require access to accelerators (i.e., GPUs, 
+TPUs).
+
+[gcp]: https://cloud.google.com/docs/get-started
+[gcloud]: https://cloud.google.com/sdk/docs/install
+[kubectl]: https://kubernetes.io/docs/tasks/tools/
+[tkn]: https://tekton.dev/docs/cli/
+[cosign]: https://docs.sigstore.dev/system_config/installation/
+[tekton-kubeflow]: https://www.kubeflow.org/docs/components/pipelines/v1/sdk/pipelines-with-tekton/
+[tekton-chains]: https://tekton.dev/docs/chains/
+[tekton]: https://tekton.dev/docs/
+[rekor]: https://rekor.sigstore.dev
+[location]: https://cloud.google.com/artifact-registry/docs/repositories/repo-locations
+[gke]: https://cloud.google.com/kubernetes-engine?hl=en
+[ar]: https://cloud.google.com/artifact-registry
+[sigstore]: https://docs.sigstore.dev 

--- a/slsa_for_models/gcp/pipeline.yml
+++ b/slsa_for_models/gcp/pipeline.yml
@@ -1,0 +1,91 @@
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: slsa-for-models
+spec:
+  workspaces:
+    - name: shared
+  params:
+    - name: tool-versions
+      properties:
+        python: {}
+        gcloud: {}
+      default:
+        python: '3.11'
+        gcloud: 'slim'
+    - name: model-source
+      properties:
+        url: {}
+        revision: {}
+        requirements-path: {}
+        main-path: {}
+      default:
+        url: 'https://github.com/google/model-transparency'
+        revision: 'main'
+        requirements-path: 'slsa_for_models/install/requirements.txt'
+        main-path: 'slsa_for_models/main.py'
+    - name: model-name
+      enum:
+        - 'tensorflow_model.keras'
+        - 'tensorflow_hdf5_model.h5'
+        - 'tensorflow_hdf5.weights.h5'
+        - 'pytorch_model.pth'
+        - 'pytorch_full_model.pth'
+        - 'pytorch_jitted_model.pt'
+    - name: model-storage
+      properties:
+        package: {}
+        location: {}
+        repository: {}
+  results:
+    - name: source_ARTIFACT_INPUTS
+      value: $(tasks.git-clone.results.source_ARTIFACT_INPUTS[*])
+    - name: model_ARTIFACT_OUTPUTS
+      value: $(tasks.upload-model.results.model_ARTIFACT_OUTPUTS[*])
+  tasks:
+    - name: git-clone
+      workspaces:
+        - name: output
+          workspace: shared
+      params:
+        - name: url
+          value: $(params.model-source.url)
+        - name: revision
+          value: $(params.model-source.revision)
+      taskRef:
+        name: git-clone
+    - name: build-model
+      runAfter:
+        - git-clone
+      workspaces:
+        - name: source
+          workspace: shared
+      params:
+        - name: model-name
+          value: $(params.model-name)
+        - name: model-source
+          value:
+            requirements-path: $(params.model-source.requirements-path)
+            main-path: $(params.model-source.main-path)
+        - name: python-version
+          value: $(params.tool-versions.python)
+      taskRef:
+        name: build-model
+    - name: upload-model
+      runAfter:
+        - build-model
+      workspaces:
+        - name: shared
+      params:
+        - name: config
+          value:
+            package: $(params.model-storage.package)
+            version: $(tasks.build-model.results.digest)
+            source: $(params.model-name)
+            location: $(params.model-storage.location)
+            repository: $(params.model-storage.repository)
+        - name: tool-versions
+          value:
+            gcloud: $(params.tool-versions.gcloud)
+      taskRef:
+        name: upload-model

--- a/slsa_for_models/gcp/pipelinerun.yml
+++ b/slsa_for_models/gcp/pipelinerun.yml
@@ -1,0 +1,24 @@
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  generateName: slsa-for-models-
+spec:
+  params:
+    - name: model-name
+      value: 'pytorch_model.pth'
+    - name: model-storage
+      value:
+        package: 'pytorch-model'
+        location: 'us'
+        repository: 'ml-artifacts'
+  pipelineRef:
+    name: slsa-for-models
+  workspaces:
+    - name: shared
+      volumeClaimTemplate:
+        spec:
+          accessModes:
+            - ReadWriteOnce
+          resources:
+            requests:
+              storage: 1Gi

--- a/slsa_for_models/gcp/tasks/build-model.yml
+++ b/slsa_for_models/gcp/tasks/build-model.yml
@@ -1,0 +1,41 @@
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  name: build-model
+spec:
+  workspaces:
+    - name: source
+  params:
+    - name: tool-versions
+      properties:
+        python: { }
+        bash: { }
+      default:
+        python: '3.11'
+        bash: 'latest'
+    - name: model-source
+      properties:
+        requirements-path: {}
+        main-path: {}
+    - name: model-name
+      enum:
+        - 'tensorflow_model.keras'
+        - 'tensorflow_hdf5_model.h5'
+        - 'tensorflow_hdf5.weights.h5'
+        - 'pytorch_model.pth'
+        - 'pytorch_full_model.pth'
+        - 'pytorch_jitted_model.pt'
+  results:
+    - name: digest
+  steps:
+    - name: run-script
+      image: docker.io/python:$(params.tool-versions.python)
+      workingDir: $(workspaces.source.path)
+      script: |
+        python -m pip install --require-hashes -r $(params.model-source.requirements-path)
+        python $(params.model-source.main-path) $(params.model-name)
+    - name: compute-digest
+      image: bash:$(params.tool-versions.bash)
+      workingDir: $(workspaces.source.path)
+      script:
+        sha256sum $(params.model-name) | awk '{print $1}' | tr -d '\n' | tee $(results.digest.path)

--- a/slsa_for_models/gcp/tasks/git-clone.yml
+++ b/slsa_for_models/gcp/tasks/git-clone.yml
@@ -1,0 +1,251 @@
+# copied from https://github.com/tektoncd/catalog/tree/main/task/git-clone/0.7
+# and modified to contain type hinting for provenance generation -- remove when
+# the catalog updates the task to support type hinting
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: git-clone
+  labels:
+    app.kubernetes.io/version: "0.7"
+  annotations:
+    tekton.dev/pipelines.minVersion: "0.29.0"
+    tekton.dev/categories: Git
+    tekton.dev/tags: git
+    tekton.dev/displayName: "git clone"
+    tekton.dev/platforms: "linux/amd64,linux/s390x,linux/ppc64le,linux/arm64"
+spec:
+  description: >-
+    These Tasks are Git tasks to work with repositories used by other tasks
+    in your Pipeline.
+
+    The git-clone Task will clone a repo from the provided url into the
+    output Workspace. By default the repo will be cloned into the root of
+    your Workspace. You can clone into a subdirectory by setting this Task's
+    subdirectory param. This Task also supports sparse checkouts. To perform
+    a sparse checkout, pass a list of comma separated directory patterns to
+    this Task's sparseCheckoutDirectories param.
+  workspaces:
+    - name: output
+      description: The git repo will be cloned onto the volume backing this Workspace.
+    - name: ssh-directory
+      optional: true
+      description: |
+        A .ssh directory with private key, known_hosts, config, etc. Copied to
+        the user's home before git commands are executed. Used to authenticate
+        with the git remote when performing the clone. Binding a Secret to this
+        Workspace is strongly recommended over other volume types.
+    - name: basic-auth
+      optional: true
+      description: |
+        A Workspace containing a .gitconfig and .git-credentials file. These
+        will be copied to the user's home before any git commands are run. Any
+        other files in this Workspace are ignored. It is strongly recommended
+        to use ssh-directory over basic-auth whenever possible and to bind a
+        Secret to this Workspace over other volume types.
+    - name: ssl-ca-directory
+      optional: true
+      description: |
+        A workspace containing CA certificates, this will be used by Git to
+        verify the peer with when fetching or pushing over HTTPS.
+  params:
+    - name: url
+      description: Repository URL to clone from.
+      type: string
+    - name: revision
+      description: Revision to checkout. (branch, tag, sha, ref, etc...)
+      type: string
+      default: ""
+    - name: refspec
+      description: Refspec to fetch before checking out revision.
+      default: ""
+    - name: submodules
+      description: Initialize and fetch git submodules.
+      type: string
+      default: "true"
+    - name: depth
+      description: Perform a shallow clone, fetching only the most recent N commits.
+      type: string
+      default: "1"
+    - name: sslVerify
+      description: Set the `http.sslVerify` global git config. Setting this to `false` is not advised unless you are sure that you trust your git remote.
+      type: string
+      default: "true"
+    - name: crtFileName
+      description: file name of mounted crt using ssl-ca-directory workspace. default value is ca-bundle.crt.
+      type: string
+      default: "ca-bundle.crt"
+    - name: subdirectory
+      description: Subdirectory inside the `output` Workspace to clone the repo into.
+      type: string
+      default: ""
+    - name: sparseCheckoutDirectories
+      description: Define the directory patterns to match or exclude when performing a sparse checkout.
+      type: string
+      default: ""
+    - name: deleteExisting
+      description: Clean out the contents of the destination directory if it already exists before cloning.
+      type: string
+      default: "true"
+    - name: httpProxy
+      description: HTTP proxy server for non-SSL requests.
+      type: string
+      default: ""
+    - name: httpsProxy
+      description: HTTPS proxy server for SSL requests.
+      type: string
+      default: ""
+    - name: noProxy
+      description: Opt out of proxying HTTP/HTTPS requests.
+      type: string
+      default: ""
+    - name: verbose
+      description: Log the commands that are executed during `git-clone`'s operation.
+      type: string
+      default: "true"
+    - name: gitInitImage
+      description: The image providing the git-init binary that this Task runs.
+      type: string
+      default: "gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/git-init:v0.29.0"
+    - name: userHome
+      description: |
+        Absolute path to the user's home directory. Set this explicitly if you are running the image as a non-root user or have overridden
+        the gitInitImage param with an image containing custom user configuration.
+      type: string
+      default: "/tekton/home"
+  results:
+    - name: commit
+      description: The precise commit SHA that was fetched by this Task.
+    - name: url
+      description: The precise URL that was fetched by this Task.
+    - name: source_ARTIFACT_INPUTS
+      properties:
+        uri: { }
+        digest: { }
+  steps:
+    - name: clone
+      image: "$(params.gitInitImage)"
+      env:
+        - name: HOME
+          value: "$(params.userHome)"
+        - name: PARAM_URL
+          value: $(params.url)
+        - name: PARAM_REVISION
+          value: $(params.revision)
+        - name: PARAM_REFSPEC
+          value: $(params.refspec)
+        - name: PARAM_SUBMODULES
+          value: $(params.submodules)
+        - name: PARAM_DEPTH
+          value: $(params.depth)
+        - name: PARAM_SSL_VERIFY
+          value: $(params.sslVerify)
+        - name: PARAM_CRT_FILENAME
+          value: $(params.crtFileName)
+        - name: PARAM_SUBDIRECTORY
+          value: $(params.subdirectory)
+        - name: PARAM_DELETE_EXISTING
+          value: $(params.deleteExisting)
+        - name: PARAM_HTTP_PROXY
+          value: $(params.httpProxy)
+        - name: PARAM_HTTPS_PROXY
+          value: $(params.httpsProxy)
+        - name: PARAM_NO_PROXY
+          value: $(params.noProxy)
+        - name: PARAM_VERBOSE
+          value: $(params.verbose)
+        - name: PARAM_SPARSE_CHECKOUT_DIRECTORIES
+          value: $(params.sparseCheckoutDirectories)
+        - name: PARAM_USER_HOME
+          value: $(params.userHome)
+        - name: WORKSPACE_OUTPUT_PATH
+          value: $(workspaces.output.path)
+        - name: WORKSPACE_SSH_DIRECTORY_BOUND
+          value: $(workspaces.ssh-directory.bound)
+        - name: WORKSPACE_SSH_DIRECTORY_PATH
+          value: $(workspaces.ssh-directory.path)
+        - name: WORKSPACE_BASIC_AUTH_DIRECTORY_BOUND
+          value: $(workspaces.basic-auth.bound)
+        - name: WORKSPACE_BASIC_AUTH_DIRECTORY_PATH
+          value: $(workspaces.basic-auth.path)
+        - name: WORKSPACE_SSL_CA_DIRECTORY_BOUND
+          value: $(workspaces.ssl-ca-directory.bound)
+        - name: WORKSPACE_SSL_CA_DIRECTORY_PATH
+          value: $(workspaces.ssl-ca-directory.path)
+      script: |
+        #!/usr/bin/env sh
+        set -eu
+
+        if [ "${PARAM_VERBOSE}" = "true" ] ; then
+          set -x
+        fi
+
+
+        if [ "${WORKSPACE_BASIC_AUTH_DIRECTORY_BOUND}" = "true" ] ; then
+          cp "${WORKSPACE_BASIC_AUTH_DIRECTORY_PATH}/.git-credentials" "${PARAM_USER_HOME}/.git-credentials"
+          cp "${WORKSPACE_BASIC_AUTH_DIRECTORY_PATH}/.gitconfig" "${PARAM_USER_HOME}/.gitconfig"
+          chmod 400 "${PARAM_USER_HOME}/.git-credentials"
+          chmod 400 "${PARAM_USER_HOME}/.gitconfig"
+        fi
+
+        if [ "${WORKSPACE_SSH_DIRECTORY_BOUND}" = "true" ] ; then
+          cp -R "${WORKSPACE_SSH_DIRECTORY_PATH}" "${PARAM_USER_HOME}"/.ssh
+          chmod 700 "${PARAM_USER_HOME}"/.ssh
+          chmod -R 400 "${PARAM_USER_HOME}"/.ssh/*
+        fi
+
+        if [ "${WORKSPACE_SSL_CA_DIRECTORY_BOUND}" = "true" ] ; then
+           export GIT_SSL_CAPATH="${WORKSPACE_SSL_CA_DIRECTORY_PATH}"
+           if [ "${PARAM_CRT_FILENAME}" != "" ] ; then
+              export GIT_SSL_CAINFO="${WORKSPACE_SSL_CA_DIRECTORY_PATH}/${PARAM_CRT_FILENAME}"
+           fi
+        fi
+        CHECKOUT_DIR="${WORKSPACE_OUTPUT_PATH}/${PARAM_SUBDIRECTORY}"
+
+        cleandir() {
+          # Delete any existing contents of the repo directory if it exists.
+          #
+          # We don't just "rm -rf ${CHECKOUT_DIR}" because ${CHECKOUT_DIR} might be "/"
+          # or the root of a mounted volume.
+          if [ -d "${CHECKOUT_DIR}" ] ; then
+            # Delete non-hidden files and directories
+            rm -rf "${CHECKOUT_DIR:?}"/*
+            # Delete files and directories starting with . but excluding ..
+            rm -rf "${CHECKOUT_DIR}"/.[!.]*
+            # Delete files and directories starting with .. plus any other character
+            rm -rf "${CHECKOUT_DIR}"/..?*
+          fi
+        }
+
+        if [ "${PARAM_DELETE_EXISTING}" = "true" ] ; then
+          cleandir
+        fi
+
+        test -z "${PARAM_HTTP_PROXY}" || export HTTP_PROXY="${PARAM_HTTP_PROXY}"
+        test -z "${PARAM_HTTPS_PROXY}" || export HTTPS_PROXY="${PARAM_HTTPS_PROXY}"
+        test -z "${PARAM_NO_PROXY}" || export NO_PROXY="${PARAM_NO_PROXY}"
+
+        /ko-app/git-init \
+          -url="${PARAM_URL}" \
+          -revision="${PARAM_REVISION}" \
+          -refspec="${PARAM_REFSPEC}" \
+          -path="${CHECKOUT_DIR}" \
+          -sslVerify="${PARAM_SSL_VERIFY}" \
+          -submodules="${PARAM_SUBMODULES}" \
+          -depth="${PARAM_DEPTH}" \
+          -sparseCheckoutDirectories="${PARAM_SPARSE_CHECKOUT_DIRECTORIES}"
+        cd "${CHECKOUT_DIR}"
+        RESULT_SHA="$(git rev-parse HEAD)"
+        EXIT_CODE="$?"
+        if [ "${EXIT_CODE}" != 0 ] ; then
+          exit "${EXIT_CODE}"
+        fi
+        printf "%s" "${RESULT_SHA}" > "$(results.commit.path)"
+        printf "%s" "${PARAM_URL}" > "$(results.url.path)"
+        
+        # type hinting for provenance generation
+        cat <<EOF | tee $(results.source_ARTIFACT_INPUTS.path)
+        {
+          "uri": "${PARAM_URL}",
+          "digest": "sha256:${RESULT_SHA}"
+        }
+        EOF

--- a/slsa_for_models/gcp/tasks/upload-model.yml
+++ b/slsa_for_models/gcp/tasks/upload-model.yml
@@ -1,0 +1,64 @@
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  name: upload-model
+spec:
+  workspaces:
+    - name: shared
+  params:
+    - name: tool-versions
+      properties:
+        gcloud: { }
+      default:
+        gcloud: 'slim'
+    - name: config
+      properties:
+        package: {}
+        version: {}
+        source: {}
+        location: {}
+        repository: {}
+  results:
+    - name: output
+    - name: json
+    - name: version
+    - name: model_ARTIFACT_OUTPUTS
+      properties:
+        uri: {}
+        digest: {}
+  steps:
+    - name: upload-to-generic-repo
+      image: gcr.io/google.com/cloudsdktool/cloud-sdk:$(params.tool-versions.gcloud)
+      workingDir: $(workspaces.shared.path)
+      script: |
+        gcloud $@
+      args:
+        - artifacts
+        - generic
+        - upload
+        - --package=$(params.config.package)
+        - --version=$(params.config.version)
+        - --source=$(params.config.source)
+        - --location=$(params.config.location)
+        - --repository=$(params.config.repository)
+      stdoutConfig:
+        path: $(results.output.path)
+    - name: convert-to-json
+      image: docker.io/stedolan/jq@sha256:a61ed0bca213081b64be94c5e1b402ea58bc549f457c2682a86704dd55231e09
+      script: |
+        jq -R -n -c '[inputs|split(": ")|{(.[0]):.[1]}] | add' $(results.output.path)
+      stdoutConfig:
+        path: $(results.json.path)
+    - name: type-hint
+      image: docker.io/stedolan/jq@sha256:a61ed0bca213081b64be94c5e1b402ea58bc549f457c2682a86704dd55231e09
+      script: |        
+        FULL=$(cat $(results.json.path) | jq -rj '.name')
+        URI=$(echo $FULL | cut -d ":" -f 1)
+        DIGEST=$(echo $FULL | cut -d ":" -f 2)
+        cat <<EOF | tee $(results.model_ARTIFACT_OUTPUTS.path)
+        {
+          "uri": "${URI}",
+          "digest": "sha256:${DIGEST}"
+        }
+        EOF
+        printf "%s" "${DIGEST}" > "$(results.version.path)"

--- a/slsa_for_models/github_actions.md
+++ b/slsa_for_models/github_actions.md
@@ -1,0 +1,50 @@
+## SLSA for Models in GitHub Actions
+
+This project uses [SLSA L3 GitHub generator][slsa-generator] to generate SLSA provenance
+for ML models in GitHub Actions. This happens during a [workflow][workflow] which takes
+as input the format to save the model into.
+
+When users download a given version of a model they can also check its provenance by
+using [the SLSA verifier][slsa-verifier] repository.
+
+To test, fork this repository, then head over to the Actions tab and select the
+"SLSA for ML models example" workflow. Since the workflow has a `workflow_dispatch`
+trigger, it can be invoked on demand: click the `Run workflow` button, then select the
+value for the "Name of the model" argument.
+
+![Triggering a SLSA workflow](images/slsa_trigger.png)
+
+After the workflow finishes execution, there will be two archives in the
+"Artifacts" section: one is the model that was trained and the other one is the
+SLSA provenance attached to the model.
+
+![Results of running a SLSA workflow](images/slsa_results.png)
+
+To verify the provenance, download both archives, unzip each and then run
+`slsa-verifier`, making sure to replace the `--source-uri` argument with the
+_path to your fork_. For example, for a PyTorch model, which has been [built on
+this repository](https://github.com/google/model-transparency/actions/runs/6646816974):
+
+```console
+[...]$ slsa-verifier verify-artifact \
+       --provenance-path pytorch_model.pth.intoto.jsonl \
+       --source-uri github.com/google/model-transparency \
+       pytorch_model.pth
+Verified signature against tlog entry index 45419124 at URL: https://rekor.sigstore.dev/api/v1/log/entries/24296fb24b8ad77a98dd03d23a78657e7f1efd3d9bea6988abbf23a72290a4ec7dc35c9edeab7ee1
+Verified build using builder "https://github.com/slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@refs/tags/v1.9.0" at commit ac26cbf66849cfec6f29747f4525180595c7eef0
+Verifying artifact pytorch_model.pth: PASSED
+
+PASSED: Verified SLSA provenance
+```
+
+The verification of provenance can be done just before the model gets loaded in the
+serving pipeline.
+
+[cifar10]: https://www.cs.toronto.edu/~kriz/cifar.html
+[slsa-generator]: https://github.com/slsa-framework/slsa-github-generator
+[slsa-verifier]: https://github.com/slsa-framework/slsa-verifier/
+[slsa]: https://slsa.dev
+[solarwinds]: https://www.techtarget.com/whatis/feature/SolarWinds-hack-explained-Everything-you-need-to-know
+[tekton-chains]: https://github.com/tektoncd/chains
+[tekton-kubeflow]: https://www.kubeflow.org/docs/components/pipelines/v1/sdk/pipelines-with-tekton/
+[workflow]: https://github.com/google/model-transparency/blob/main/.github/workflows/slsa_for_ml.yml


### PR DESCRIPTION
Prior to this change, SLSA for Models targeted GitHub Actions only.

In this change, we demonstrate SLSA for Models on GCP using Tekton, Sigstore, Google Kubernetes Engine and Artifact Registry.

cc @mihaimaruseac