### PR TITLE
Default ambient authority set to False in API

### DIFF
--- a/model_signing/model.py
+++ b/model_signing/model.py
@@ -64,7 +64,7 @@ class SignatureResult(BaseResult):
 
 class SigstoreSigner():
     def __init__(self,
-                 disable_ambient: bool = True,
+                 disable_ambient: bool = False,
                  start_default_browser: bool = False,
                  oidc_issuer: str = None):
         self.signing_ctx = SigningContext.production()


### PR DESCRIPTION
I changed this by mistake in my previous PR