### PR TITLE
Remote Resolution of Tasks

### DIFF
--- a/slsa_for_models/gcp/README.md
+++ b/slsa_for_models/gcp/README.md
@@ -117,13 +117,39 @@ This project uses [Tekton][tekton] to generate SLSA provenance for ML models on 
    cosign generate-key-pair k8s://tekton-chains/signing-secrets
    ```
  
-8. Apply the `Tasks`:
+8. (Optional) View the Tekton resources:
+   
+   1. View the git-clone `Task`:
 
-   ```shell
-   kubectl apply -f slsa_for_models/gcp/tasks
-   ```
+      ```shell
+      cat slsa_for_models/gcp/tasks/git-clone.yml
+      ```
 
-9. Apply the `Pipeline`:
+   2. View the build-model `Task`:
+
+      ```shell
+      cat slsa_for_models/gcp/tasks/build-model.yml
+      ```
+
+   3. View the upload-model `Task`:
+
+      ```shell
+      cat slsa_for_models/gcp/tasks/upload-model.yml
+      ```
+   
+   4. View the `Pipeline`:
+
+      ```shell
+      cat slsa_for_models/gcp/pipeline.yml
+      ```
+
+   5. View the `PipelineRun`:
+
+      ```shell
+      cat slsa_for_models/gcp/pipelinerun.yml
+      ```
+   
+9.  Apply the `Pipeline`:
 
    ```shell
    kubectl apply -f slsa_for_models/gcp/pipeline.yml
@@ -192,15 +218,16 @@ This project uses [Tekton][tekton] to generate SLSA provenance for ML models on 
    cat pytorch_model.pth.build-slsa | tr -d '\n' | pbcopy
    pbpaste | jq '.payload | @base64d | fromjson'
    ```
+
 17. Download the model:
 
    ```shell
-   export MODEL_VERSION=$(tkn pr describe slsa-for-models-pr --output jsonpath='{.status.results[1].value.digest}' | cut -d ':' -f 2)
+   export MODEL_VERSION=$(tkn pr describe $PIPELINERUN_NAME --output jsonpath='{.status.results[1].value.digest}' | cut -d ':' -f 2)
    gcloud artifacts generic download \
    --package=pytorch-model \
    --repository=$REPOSITORY_NAME \
    --destination=. \
-   --version="${MODEL_VERSION:7}"
+   --version=$MODEL_VERSION
    ```
 
 18. Verify the attestation:

--- a/slsa_for_models/gcp/pipeline.yml
+++ b/slsa_for_models/gcp/pipeline.yml
@@ -53,7 +53,14 @@ spec:
         - name: revision
           value: $(params.model-source.revision)
       taskRef:
-        name: git-clone
+        resolver: git
+        params:
+        - name: url
+          value: https://github.com/google/model-transparency.git
+        - name: revision
+          value: $(params.model-source.revision)
+        - name: pathInRepo
+          value: slsa_for_models/gcp/tasks/git-clone.yml
     - name: build-model
       runAfter:
         - git-clone
@@ -70,7 +77,14 @@ spec:
         - name: python-version
           value: $(params.tool-versions.python)
       taskRef:
-        name: build-model
+        resolver: git
+        params:
+        - name: url
+          value: https://github.com/google/model-transparency.git
+        - name: revision
+          value: $(params.model-source.revision)
+        - name: pathInRepo
+          value: slsa_for_models/gcp/tasks/build-model.yml
     - name: upload-model
       runAfter:
         - build-model
@@ -88,4 +102,11 @@ spec:
           value:
             gcloud: $(params.tool-versions.gcloud)
       taskRef:
-        name: upload-model
+        resolver: git
+        params:
+        - name: url
+          value: https://github.com/google/model-transparency.git
+        - name: revision
+          value: $(params.model-source.revision)
+        - name: pathInRepo
+          value: slsa_for_models/gcp/tasks/upload-model.yml

--- a/slsa_for_models/gcp/tasks/upload-model.yml
+++ b/slsa_for_models/gcp/tasks/upload-model.yml
@@ -21,7 +21,6 @@ spec:
   results:
     - name: output
     - name: json
-    - name: version
     - name: model_ARTIFACT_OUTPUTS
       properties:
         uri: {}
@@ -61,4 +60,4 @@ spec:
           "digest": "sha256:${DIGEST}"
         }
         EOF
-        printf "%s" "${DIGEST}" > "$(results.version.path)"
+


### PR DESCRIPTION
Prior to this change, the project used Tasks applied directly to the cluster. In this change, we switch to [remote resolution] of Tasks in a Pipeline. This is aligned with the  "config as code" recommendation, where build definitions are fetched from a version control system.

In addition, we make a few minor changes:
- cleanup the documentation
- remove unused result from the upload-model task

[remote resolution]: https://tekton.dev/docs/pipelines/resolution/

cc @mihaimaruseac @laurentsimon 